### PR TITLE
Windows build fixes.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,8 @@ set(ENTROPY_CORE_HEADERS
         src/EntropyCore.h
         src/ServiceLocator.h
         src/TypeSystem/GenericHandle.h
+        src/TypeSystem/TypeID.h
+        src/TypeSystem/Reflection.h
         src/Graph/DirectedAcyclicGraph.h
         src/Graph/AcyclicNodeHandle.h
         src/Debug/INamed.h

--- a/src/Concurrency/NodeScheduler.cpp
+++ b/src/Concurrency/NodeScheduler.cpp
@@ -14,6 +14,11 @@
 #include <algorithm>
 #include <format>
 
+#ifdef EntropyDarwin
+using std::min;
+using std::max;
+#endif
+
 namespace EntropyEngine {
 namespace Core {
 namespace Concurrency {

--- a/src/Concurrency/NodeScheduler.cpp
+++ b/src/Concurrency/NodeScheduler.cpp
@@ -110,7 +110,7 @@ bool NodeScheduler::deferNode(NodeHandle node) {
     // Track peak deferred count
     {
         std::lock_guard<std::mutex> statsLock(_statsMutex);
-        _stats.peakDeferred = std::max(_stats.peakDeferred, _deferredQueue.size());
+        _stats.peakDeferred = max(_stats.peakDeferred, _deferredQueue.size());
     }
     
     // Publish event
@@ -144,7 +144,7 @@ size_t NodeScheduler::processDeferredNodes(size_t maxToSchedule) {
     {
         std::lock_guard<std::shared_mutex> lock(_deferredMutex);  // Exclusive lock for modifying queue
         
-        size_t count = std::min(toProcess, _deferredQueue.size());
+        size_t count = min(toProcess, _deferredQueue.size());
         nodesToSchedule.reserve(count);
         
         for (size_t i = 0; i < count; ++i) {
@@ -174,7 +174,7 @@ size_t NodeScheduler::scheduleReadyNodes(const std::vector<NodeHandle>& nodes) {
     if (_config.enableBatchScheduling && nodes.size() > 1) {
         // Schedule in batches for better efficiency
         for (size_t i = 0; i < nodes.size(); i += _config.batchSize) {
-            size_t batchEnd = std::min(i + _config.batchSize, nodes.size());
+            size_t batchEnd = min(i + _config.batchSize, nodes.size());
             
             for (size_t j = i; j < batchEnd; ++j) {
                 if (scheduleNode(nodes[j])) {


### PR DESCRIPTION
* Adds a type alias for macOS specifically for std::min and std::max to work around these two not being available on Windows under the std namespace (for some reason)
* Uses min and max outside of the std namespace on Windows because they seemingly are not available otherwise.